### PR TITLE
feat: enhance validation and documentation for Oracle deployment 

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -319,17 +319,20 @@
             {
               "key": "ora_db_password",
               "display_name": "Oracle SYS Password",
+              "description": "Password for Oracle database administrative users (SYS, SYSTEM). Password must be 15-30 characters long and contain at least one uppercase letter, one lowercase letter, one digit, and one special character (e.g., !@#$%^&*). This password is required for database administration and must meet Oracle password complexity requirements.",
               "default_value": "",
               "type": "password",
               "required": true,
               "value_constraints": [
                 {
                   "type": "regex",
-                  "value": "^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[^A-Za-z0-9]).+$"
+                  "value": "^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[^A-Za-z0-9]).+$",
+                  "description": "Password must contain at least one uppercase letter, one lowercase letter, one digit, and one special character"
                 },
                 {
                   "type": "regex",
-                  "value": "^.{8,30}$"
+                  "value": "^.{15,30}$",
+                  "description": "Password must be between 15 and 30 characters"
                 }
               ],
               "custom_config": {}
@@ -403,6 +406,7 @@
             {
               "key": "pi_oravg_volume",
               "display_name": "Oracle Software Binary Disks",
+              "description": "Disk configuration for the Oracle software volume group (oravg). Total filesystem size (size × count) must be at least 120GB to accommodate Oracle binaries, patches, and Grid Infrastructure. Fields: size (disk size in GB), count (number of disks), tier (storage tier, e.g., tier1 or tier3). Example: size=100GB × count=2 = 200GB total.",
               "required": false,
               "custom_config": {
                 "grouping": "deployment",
@@ -827,17 +831,20 @@
             {
               "key": "root_password",
               "display_name": "RAC Nodes Root User Password",
+              "description": "Root user password for all Oracle RAC AIX virtual server instances. Password must be 15-30 characters long and contain at least one uppercase letter, one lowercase letter, one digit, and one special character (e.g., !@#$%^&*). This password is set on each RAC node during provisioning and is required for administrative access.",
               "type": "password",
               "default_value": "",
               "required": true,
               "value_constraints": [
                 {
                   "type": "regex",
-                  "value": "^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[^A-Za-z0-9]).+$"
+                  "value": "^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[^A-Za-z0-9]).+$",
+                  "description": "Password must contain at least one uppercase letter, one lowercase letter, one digit, and one special character"
                 },
                 {
                   "type": "regex",
-                  "value": "^.{8,30}$"
+                  "value": "^.{15,30}$",
+                  "description": "Password must be between 15 and 30 characters"
                 }
               ],
               "custom_config": {}
@@ -942,17 +949,20 @@
             {
               "key": "ora_db_password",
               "display_name": "Oracle SYS Password",
+              "description": "Password for Oracle database administrative users (SYS, SYSTEM). Password must be 15-30 characters long and contain at least one uppercase letter, one lowercase letter, one digit, and one special character (e.g., !@#$%^&*). This password is required for database administration and must meet Oracle password complexity requirements.",
               "default_value": "",
               "type": "password",
               "required": true,
               "value_constraints": [
                 {
                   "type": "regex",
-                  "value": "^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[^A-Za-z0-9]).+$"
+                  "value": "^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[^A-Za-z0-9]).+$",
+                  "description": "Password must contain at least one uppercase letter, one lowercase letter, one digit, and one special character"
                 },
                 {
                   "type": "regex",
-                  "value": "^.{8,30}$"
+                  "value": "^.{15,30}$",
+                  "description": "Password must be between 15 and 30 characters"
                 }
               ],
               "custom_config": {}
@@ -1009,6 +1019,7 @@
             {
               "key": "pi_oravg_volume",
               "display_name": "Oracle Software Binary Disks",
+              "description": "Disk configuration for the Oracle software volume group (oravg). Total filesystem size (size × count) must be at least 120GB to accommodate Oracle binaries, patches, and Grid Infrastructure. Fields: size (disk size in GB), count (number of disks), tier (storage tier, e.g., tier1 or tier3). Example: size=100GB × count=2 = 200GB total.",
               "required": false,
               "custom_config": {
                 "grouping": "deployment",

--- a/solutions/oracle/rac/variables.tf
+++ b/solutions/oracle/rac/variables.tf
@@ -64,7 +64,7 @@ variable "pi_aix_image_name" {
 }
 
 variable "pi_aix_instance" {
-  description = "Configuration for the IBM PowerVS AIX instance where Oracle RAC will be installed. This configuration is applied to each RAC node. Fields: memory_gb (RAM in GB), cores (number of virtual processors), core_type (shared | capped | dedicated), machine_type (e.g., s1022 or e980), pin_policy (hard | soft), health_status (OK | Warning | Critical)."
+  description = "Configuration for the IBM PowerVS AIX instance where Oracle RAC will be installed. This configuration is applied to each RAC node. Fields: memory_gb (RAM in GB, minimum 24GB), cores (number of virtual processors), core_type (shared | capped | dedicated), machine_type (e.g., s1022 or e980), pin_policy (hard | soft), health_status (OK | Warning | Critical)."
   type = object({
     memory_gb     = number
     cores         = optional(number)
@@ -73,6 +73,11 @@ variable "pi_aix_instance" {
     pin_policy    = string
     health_status = string
   })
+
+  validation {
+    condition     = var.pi_aix_instance.memory_gb >= 24
+    error_message = "AIX instance memory_gb must be at least 24GB. Current value: ${var.pi_aix_instance.memory_gb}GB"
+  }
 }
 
 variable "pi_replication_policy" {

--- a/solutions/oracle/si/variables.tf
+++ b/solutions/oracle/si/variables.tf
@@ -64,7 +64,7 @@ variable "pi_aix_image_name" {
 }
 
 variable "pi_aix_instance" {
-  description = "Configuration for the IBM PowerVS AIX instance where Oracle Database will be installed. Fields: memory_gb (RAM in GB), cores (number of virtual processors), core_type (shared | capped | dedicated), machine_type (e.g., s1022 or e980), pin_policy (hard | soft), health_status (OK | Warning | Critical)."
+  description = "Configuration for the IBM PowerVS AIX instance where Oracle Database will be installed. Fields: memory_gb (RAM in GB, minimum 24GB), cores (number of virtual processors), core_type (shared | capped | dedicated), machine_type (e.g., s1022 or e980), pin_policy (hard | soft), health_status (OK | Warning | Critical)."
   type = object({
     memory_gb     = number
     cores         = optional(number)
@@ -73,6 +73,11 @@ variable "pi_aix_instance" {
     pin_policy    = string
     health_status = string
   })
+
+  validation {
+    condition     = var.pi_aix_instance.memory_gb >= 24
+    error_message = "AIX instance memory_gb must be at least 24GB. Current value: ${var.pi_aix_instance.memory_gb}GB"
+  }
 }
 
 variable "pi_networks" {


### PR DESCRIPTION
feat: enhance validation and documentation for Oracle deployment parameters

- Add AIX instance memory validation requiring minimum 24GB
  * Updated pi_aix_instance validation in solutions/oracle/si/variables.tf
  * Updated pi_aix_instance validation in solutions/oracle/rac/variables.tf
  * Added clear error messages showing current vs required values

- Update password requirements to 15-30 characters in ibm_catalog.json
  * Enhanced root_password description with detailed requirements
  * Enhanced ora_db_password (SYS) description with complexity rules
  * Updated regex validation from 8-30 to 15-30 characters
  * Added descriptive messages for each validation constraint

- Add Oracle Binary disks filesystem size documentation
  * Added comprehensive description for pi_oravg_volume parameter
  * Documented 120GB minimum total filesystem requirement
  * Included calculation example (size × count = total)
  * Applied to both SI and RAC deployment flavors


